### PR TITLE
fix milestone missing (w/ over 30 OPEN milestones)

### DIFF
--- a/lib/ghissues/ghissues.rb
+++ b/lib/ghissues/ghissues.rb
@@ -16,10 +16,11 @@ class Ghissues
       c.login = user
       c.access_token = token
     end
+    Octokit.auto_paginate = true # e.g. over 30 OPEN milestones
   end
 
   def self.fetchMilestones(repo)
-    @@milestones = Octokit.list_milestones(repo)
+    @@milestones = Octokit.list_milestones(repo, direction: "desc")
   end
 
   def self.milestoneText2number(str)


### PR DESCRIPTION
Github API の仕様で30を越えるレスポンスが含まれる場合ページネーションが発生する様子。
このため、現行のマイルストーン取得のロジックでは、30を越える Open ステータスのマイルストーンがある場合に意図したとおり動作しない。
このため、 Octokit ライブラリのコンフィグによりページネーションも含めて処理するよう修正した。
マイルストーンが大量にある場合に、主にパフォーマンス関連の問題が発生する可能性はある。

※direction: desc は必須ではないがユースケース的に若干のパフォーマンスアドバンテージがあると判断してオマケでいれてある。